### PR TITLE
Use api host if schema host is undefined

### DIFF
--- a/lib/utils/SpecManager.ts
+++ b/lib/utils/SpecManager.ts
@@ -43,7 +43,7 @@ export class SpecManager {
   /* calculate common used values */
   init() {
     let protocol;
-    const urlParts = urlParse(this._url);
+    let urlParts = urlParse(this._url);
     if (!this._schema.schemes || !this._schema.schemes.length) {
       protocol = this._url ? urlParts.protocol : 'http';
     } else {

--- a/lib/utils/SpecManager.ts
+++ b/lib/utils/SpecManager.ts
@@ -43,15 +43,17 @@ export class SpecManager {
   /* calculate common used values */
   init() {
     let protocol;
+    const urlParts = urlParse(this._url);
     if (!this._schema.schemes || !this._schema.schemes.length) {
-      protocol = this._url ? urlParse(this._url).protocol : 'http';
+      protocol = this._url ? urlParts.protocol : 'http';
     } else {
       protocol = this._schema.schemes[0];
       if (protocol === 'http' && this._schema.schemes.indexOf('https') >= 0) {
         protocol = 'https';
       }
     }
-    this.apiUrl = protocol + '://' + this._schema.host + this._schema.basePath;
+    let host = (!this._schema.host && urlParts.host) ? urlParts.host : this._schema.host;
+    this.apiUrl = protocol + '://' + host + this._schema.basePath;
     if (this.apiUrl.endsWith('/')) {
       this.apiUrl = this.apiUrl.substr(0, this.apiUrl.length - 1);
     }

--- a/lib/utils/SpecManager.ts
+++ b/lib/utils/SpecManager.ts
@@ -42,17 +42,20 @@ export class SpecManager {
 
   /* calculate common used values */
   init() {
+    let urlParts = this._url ? urlParse(this._url) : {};
+    let schemes = this._schema.schemes;
     let protocol;
-    let urlParts = urlParse(this._url);
-    if (!this._schema.schemes || !this._schema.schemes.length) {
-      protocol = this._url ? urlParts.protocol : 'http';
+    if (!schemes || !schemes.length) {
+      // url parser incudles ':' in protocol so remove it
+      protocol = urlParts.protocol ? urlParts.protocol.slice(0, -1) : 'http';
     } else {
-      protocol = this._schema.schemes[0];
-      if (protocol === 'http' && this._schema.schemes.indexOf('https') >= 0) {
+      protocol = schemes[0];
+      if (protocol === 'http' && schemes.indexOf('https') >= 0) {
         protocol = 'https';
       }
     }
-    let host = (!this._schema.host && urlParts.host) ? urlParts.host : this._schema.host;
+
+    let host = this._schema.host || urlParts.host;
     this.apiUrl = protocol + '://' + host + this._schema.basePath;
     if (this.apiUrl.endsWith('/')) {
       this.apiUrl = this.apiUrl.substr(0, this.apiUrl.length - 1);

--- a/tests/unit/SpecManager.spec.ts
+++ b/tests/unit/SpecManager.spec.ts
@@ -59,6 +59,13 @@ describe('Utils', () => {
         specMgr.apiUrl.should.be.equal('https://petstore.swagger.io/v2');
       });
 
+      it('should substitute api scheme when spec schemes are undefined', () => {
+        specMgr._schema.schemes = undefined;
+        specMgr._url = 'https://petstore.swagger.io/v2';
+        specMgr.init();
+        specMgr.apiUrl.should.be.equal('https://petstore.swagger.io/v2');
+      });
+
       it('should substitute api host when spec host is undefined', () => {
         specMgr._schema.host = undefined;
         specMgr._url = 'https://petstore.swagger.io/v2';

--- a/tests/unit/SpecManager.spec.ts
+++ b/tests/unit/SpecManager.spec.ts
@@ -59,6 +59,13 @@ describe('Utils', () => {
         specMgr.apiUrl.should.be.equal('https://petstore.swagger.io/v2');
       });
 
+      it('should substitute api host when spec host is undefined', () => {
+        specMgr._schema.host = undefined;
+        specMgr._url = 'https://petstore.swagger.io/v2';
+        specMgr.init();
+        specMgr.apiUrl.should.be.equal('https://petstore.swagger.io/v2');
+      });
+
       describe('byPointer method', () => {
         it('should return correct schema part', ()=> {
           let part = specMgr.byPointer('/tags/3');


### PR DESCRIPTION
Small update to fix fallback of host.

If `schema.host` is undefined then use host serving spec document, if one exists. [ref](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema)

Also fixed up an issue with scheme fallback where url parser returns a protocol with `:` at the end causing an invalid url