### PR TITLE
support "x-nullable" property

### DIFF
--- a/demo/swagger.yaml
+++ b/demo/swagger.yaml
@@ -819,6 +819,7 @@ definitions:
         type: string
         pattern: "^\\+(?:[0-9]-?){6,14}[0-9]$"
         example: +1-202-555-0192
+        x-nullable: true
       userStatus:
         description: User status
         type: integer

--- a/lib/components/JsonSchema/_json-schema-common.scss
+++ b/lib/components/JsonSchema/_json-schema-common.scss
@@ -63,6 +63,14 @@ $sub-schema-offset: ($bullet-size / 2) + $bullet-margin;
   font-weight: bold;
 }
 
+.param-nullable {
+  vertical-align: middle;
+  line-height: $param-name-height;
+  color: #3195a6;
+  font-size: 12px;
+  font-weight: bold;
+}
+
 .param-type {
   vertical-align: middle;
   line-height: $param-name-height;

--- a/lib/components/JsonSchema/json-schema.html
+++ b/lib/components/JsonSchema/json-schema.html
@@ -70,6 +70,7 @@
               <span class="param-range" *ngIf="prop._range"> {{prop._range}} </span>
               </span>
               <span *ngIf="prop._required" class="param-required">Required</span>
+              <span *ngIf="prop._nullable" class="param-nullable">Nullable</span>
               <div *ngIf="prop.default">Default: {{prop.default | json}}</div>
               <div *ngIf="prop.enum && !prop.isDiscriminator" class="param-enum">
                 <span *ngFor="let enumItem of prop.enum" class="enum-value {{enumItem.type}}"> {{enumItem.val | json}} </span>

--- a/lib/services/schema-helper.service.ts
+++ b/lib/services/schema-helper.service.ts
@@ -229,6 +229,7 @@ export class SchemaHelper {
         propertySchema._pointer = null;
       }
       propertySchema._required = !!requiredMap[propName];
+      propertySchema._nullable = !!propertySchema['x-nullable'];
       propertySchema.isDiscriminator = (schema.discriminator === propName);
       return propertySchema;
     });


### PR DESCRIPTION
Closes #92

For now, just supporting `x-nullable`. Once OpenAPI publishes a version with `nullable`, will be very easy to add support for that.

I just picked a light-blue-ish color for "Nullable" in the UI. If you would rather use some other color that is totally ok with me, let me know and I can update the PR or you can do it after in a separate commit.

Let me know if I didn't get to anything that should also be changed for this.