### PR TITLE
makes basePath optional

### DIFF
--- a/lib/utils/SpecManager.ts
+++ b/lib/utils/SpecManager.ts
@@ -56,7 +56,8 @@ export class SpecManager {
     }
 
     let host = this._schema.host || urlParts.host;
-    this.apiUrl = protocol + '://' + host + this._schema.basePath;
+    let basePath = this._schema.basePath || '/';
+    this.apiUrl = protocol + '://' + host + basePath;
     if (this.apiUrl.endsWith('/')) {
       this.apiUrl = this.apiUrl.substr(0, this.apiUrl.length - 1);
     }

--- a/tests/schemas/api-info-test.json
+++ b/tests/schemas/api-info-test.json
@@ -14,7 +14,6 @@
     }
   },
   "host": "petstore.swagger.io",
-  "basePath": "/v2/",
   "schemes": ["http"],
   "paths": {
     "/pet": {


### PR DESCRIPTION
according to the [spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object) the `basePath` isn't required,
means if they isn't provided it results in an invalid url (the `undefined` part):

![bildschirmfoto 2016-09-06 um 10 50 52](https://cloud.githubusercontent.com/assets/120214/18267675/8db9fe24-7420-11e6-9990-649596f08860.png)

this PR corrects the behaviour, so the url would be valid

![bildschirmfoto 2016-09-06 um 10 51 22](https://cloud.githubusercontent.com/assets/120214/18267711/b7f18c48-7420-11e6-8a44-7593ff70d14c.png)

