### PR TITLE
Add option to hide hostname in method definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ ReDoc makes use of the following [vendor extensions](http://swagger.io/specifica
   * **selector**: selector of the element to be used for specifying the offset. The distance from the top of the page to the element's bottom will be used as offset;
   * **function**: A getter function. Must return a number representing the offset (in pixels);
 * `suppress-warnings` - if set, warnings are not rendered at the top of documentation (they still are logged to the console).
+* `hide-hostname` - if set, the protocol and hostname is not shown in the method definition.
 
 ## Advanced usage
 Instead of adding `spec-url` attribute to the `<redoc>` element you can initialize ReDoc via globally exposed `Redoc` object:

--- a/lib/components/Method/method.ts
+++ b/lib/components/Method/method.ts
@@ -3,6 +3,7 @@ import { Input, Component, OnInit, ChangeDetectionStrategy } from '@angular/core
 import JsonPointer from '../../utils/JsonPointer';
 import { BaseComponent, SpecManager } from '../base';
 import { SchemaHelper } from '../../services/schema-helper.service';
+import { OptionsService } from '../../services/options.service';
 
 @Component({
   selector: 'method',
@@ -16,13 +17,17 @@ export class Method extends BaseComponent implements OnInit {
 
   method:any;
 
-  constructor(specMgr:SpecManager) {
+  constructor(specMgr:SpecManager, private optionsService: OptionsService) {
     super(specMgr);
   }
 
   init() {
     this.method = {};
-    this.method.apiUrl = this.specMgr.apiUrl;
+    if (this.optionsService.options.hideHostname) {
+      this.method.apiUrl = this.specMgr.basePath;
+    } else {
+      this.method.apiUrl = this.specMgr.apiUrl;
+    }
     this.method.httpMethod = JsonPointer.baseName(this.pointer);
     this.method.path = JsonPointer.baseName(this.pointer, 2);
     this.method.info = this.componentSchema;

--- a/lib/services/options.service.ts
+++ b/lib/services/options.service.ts
@@ -8,7 +8,7 @@ const defaults = {
   disableLazySchemas: false
 };
 
-const OPTION_NAMES = new Set(['scrollYOffset', 'disableLazySchemas', 'specUrl', 'suppressWarnings']);
+const OPTION_NAMES = new Set(['scrollYOffset', 'disableLazySchemas', 'specUrl', 'suppressWarnings', 'hideHostname']);
 
 @Injectable()
 export class OptionsService {
@@ -69,5 +69,7 @@ export class OptionsService {
 
     if (isString(this._options.disableLazySchemas)) this._options.disableLazySchemas = true;
     if (isString(this._options.suppressWarnings)) this._options.suppressWarnings = true;
+    if (isString(this._options.hideHostname)) this._options.hideHostname = true;
+  }
   }
 }

--- a/lib/utils/spec-manager.ts
+++ b/lib/utils/spec-manager.ts
@@ -10,6 +10,7 @@ import { MdRenderer } from './md-renderer';
 export class SpecManager {
   public _schema: any = {};
   public apiUrl: string;
+  public basePath: string;
 
   public spec = new BehaviorSubject<any|null>(null);
   private _instance: any;
@@ -65,8 +66,8 @@ export class SpecManager {
     }
 
     let host = this._schema.host || urlParts.host;
-    let basePath = this._schema.basePath || '/';
-    this.apiUrl = protocol + '://' + host + basePath;
+    this.basePath = this._schema.basePath || '/';
+    this.apiUrl = protocol + '://' + host + this.basePath;
     if (this.apiUrl.endsWith('/')) {
       this.apiUrl = this.apiUrl.substr(0, this.apiUrl.length - 1);
     }


### PR DESCRIPTION
This allows ReDoc to be used for self-hosted tools where the hostname may not be known.