### PR TITLE
Allow JSON-like examples to be shown

### DIFF
--- a/lib/components/ResponsesSamples/responses-samples.ts
+++ b/lib/components/ResponsesSamples/responses-samples.ts
@@ -3,7 +3,7 @@
 import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { BaseComponent, SpecManager } from '../base';
 import JsonPointer from '../../utils/JsonPointer';
-import { statusCodeType } from '../../utils/helpers';
+import { statusCodeType, getJsonLike } from '../../utils/helpers';
 
 
 function isNumeric(n) {
@@ -11,7 +11,7 @@ function isNumeric(n) {
 }
 
 function hasExample(response) {
-  return ((response.examples && response.examples['application/json']) ||
+  return ((response.examples && getJsonLike(response.examples)) ||
     response.schema);
 }
 

--- a/lib/components/SchemaSample/schema-sample.ts
+++ b/lib/components/SchemaSample/schema-sample.ts
@@ -6,6 +6,7 @@ import * as OpenAPISampler from 'openapi-sampler';
 
 import { BaseComponent, SpecManager } from '../base';
 import { SchemaNormalizer } from '../../services/schema-normalizer.service';
+import { getJsonLike } from '../../utils/helpers';
 
 @Component({
   selector: 'schema-sample',
@@ -42,8 +43,9 @@ export class SchemaSample extends BaseComponent implements OnInit {
       this.pointer += '/schema';
     }
 
-    if (base.examples && base.examples['application/json']) {
-      sample = base.examples['application/json'];
+    let jsonLikeSample = base.examples && getJsonLike(base.examples);
+    if (jsonLikeSample) {
+      sample = jsonLikeSample;
     } else {
       let selectedDescendant;
 

--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -114,3 +114,17 @@ export function snapshot(obj) {
 
   return temp;
 }
+
+export function isJsonLike(contentType: string): boolean {
+  return contentType.search(/json/i) !== -1;
+}
+
+export function getJsonLike(object: object) {
+  const jsonLikeKeys = Object.keys(object).filter(isJsonLike);
+
+  if (!jsonLikeKeys.length) {
+    return false;
+  }
+
+  return object[jsonLikeKeys.shift()];
+}

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,6 +1,7 @@
 'use strict';
 
-import {statusCodeType} from '../../lib/utils/helpers';
+import {statusCodeType, isJsonLike, getJsonLike } from '../../lib/utils/helpers';
+
 describe('Utils', () => {
   describe('statusCodeType', () => {
     it('Should return info for status codes within 100 and 200', ()=> {
@@ -30,4 +31,34 @@ describe('Utils', () => {
       (() => statusCodeType(600)).should.throw('invalid HTTP code');
     });
   });
+
+  describe('isJsonLike', () => {
+    it('Should return true for a string that contains `json`', () => {
+      isJsonLike('application/json').should.be.equal(true);
+    });
+    it('Should return false for a string that does not contain `json`', () => {
+      isJsonLike('application/xml').should.be.equal(false);
+    });
+  });
+
+  describe('getJsonLike', () => {
+    it('Should return a value when a JSON-like key exists', () => {
+      const examples = {
+        "application/vnd.api+json": {
+          "message": "Hello World"
+        },
+        "application/xml": "<message>Hello World</message>"
+      };
+
+      (getJsonLike(examples).message).should.be.equal("Hello World");
+    });
+
+    it('Should return undefined when no JSON-like key exists', () => {
+      const examples = {
+        "application/xml": "<message>Hello World</message>"
+      };
+
+      getJsonLike(examples).should.be.equal(false);
+    });
+  })
 });


### PR DESCRIPTION
The API my company is trying to describe with Open API implements [JSON API](http://jsonapi.org/) which dictates that the Content Type be set to `application/vnd.api+json`.

We are encouraging developers to make use of the `examples` functionality for their endpoints and noticed that the current codebase only shows examples if they matched `application/json`. This essentially meant our examples were not being displayed by ReDoc.

This change does a fuzzy match to see if the content type contains anything like `json`. It's working well for us so-far, so thought we'd share back!