### PR TITLE
Simple oneOf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ compiled
 /coverage
 .ghpages-tmp
 stats.json
+/nbproject

--- a/lib/components/JsonSchema/json-schema.html
+++ b/lib/components/JsonSchema/json-schema.html
@@ -41,6 +41,19 @@
       </template>
     </div>
   </template>
+  <template ngSwitchCase="oneOf">
+    <div class="params-wrap params-oneOf array-tuple">
+      <template ngFor [ngForOf]="schema.oneOf" let-item="$implicit" let-idx="index" [ngForTrackBy]="trackByIdx">
+        <div class="tuple-item">
+          <span class="tuple-item-index"> [{{idx}}]: </span>
+          <json-schema class="nested-schema" [pointer]="item._pointer"
+          [absolutePointer]="item._pointer"
+          [nestOdd]="!nestOdd" [isRequestSchema]="isRequestSchema">
+          </json-schema>
+        </div>
+      </template>
+    </div>
+  </template>
   <template ngSwitchCase="array">
     <json-schema class="nested-schema" [pointer]="schema._pointer"
     [nestOdd]="!nestOdd" [isRequestSchema]="isRequestSchema"> </json-schema>

--- a/lib/components/JsonSchema/json-schema.scss
+++ b/lib/components/JsonSchema/json-schema.scss
@@ -127,6 +127,12 @@ table {
   font-family: monospace;
 }
 
+.params-wrap.params-oneOf:before {
+  content: "oneOf [";
+  padding-top: 1em;
+  font-family: monospace;
+}
+
 .params-wrap.params-array:before {
   content: "Array [";
   padding-top: 1em;

--- a/lib/components/SchemaSample/schema-sample.ts
+++ b/lib/components/SchemaSample/schema-sample.ts
@@ -65,7 +65,12 @@ export class SchemaSample extends BaseComponent implements OnInit {
         return;
       }
       try {
-        sample = OpenAPISampler.sample(this.componentSchema, {
+        let schemaForSampler = this.componentSchema;
+        if (this.componentSchema.oneOf) {
+          schemaForSampler = this.componentSchema.oneOf[0];
+        }
+
+        sample = OpenAPISampler.sample(schemaForSampler, {
           skipReadOnly: this.skipReadOnly
         });
       } catch(e) {

--- a/lib/services/schema-helper.service.ts
+++ b/lib/services/schema-helper.service.ts
@@ -94,6 +94,20 @@ const injectors = {
       injectTo._widgetType = 'object';
     }
   },
+  oneOf: {
+    check: (propertySchema) => propertySchema.oneOf,
+    inject: (injectTo, propertySchema = injectTo, propPointer) => {      
+
+      injectTo._isTuple = true;
+      injectTo._displayType = '';
+      let itemsPtr = JsonPointer.join(propertySchema._pointer || propPointer, ['oneOf']);
+      for (let i=0; i < propertySchema.oneOf.length; i++) {
+        let itemSchema = propertySchema.oneOf[i];
+        itemSchema._pointer = itemSchema._pointer || JsonPointer.join(itemsPtr, [i.toString()]);
+      }
+      injectTo._widgetType = 'oneOf';
+    }
+  },
   noType: {
     check: (propertySchema) => !propertySchema.type,
     inject: (injectTo) => {
@@ -110,7 +124,7 @@ const injectors = {
         return (!propertySchema.properties || !Object.keys(propertySchema.properties).length)
           && (typeof propertySchema.additionalProperties !== 'object');
       }
-      return (propertySchema.type !== 'array') && propertySchema.type;
+      return (propertySchema.type !== 'array') && (propertySchema.type !== 'oneOf') && propertySchema.type;
     },
     inject: (injectTo, propertySchema = injectTo) => {
       injectTo.isTrivial = true;

--- a/lib/services/schema-helper.service.ts
+++ b/lib/services/schema-helper.service.ts
@@ -96,7 +96,7 @@ const injectors = {
   },
   oneOf: {
     check: (propertySchema) => propertySchema.oneOf,
-    inject: (injectTo, propertySchema = injectTo, propPointer) => {      
+    inject: (injectTo, propertySchema = injectTo, propPointer) => {
 
       injectTo._isTuple = true;
       injectTo._displayType = '';

--- a/lib/services/schema-normalizer.service.ts
+++ b/lib/services/schema-normalizer.service.ts
@@ -13,6 +13,7 @@ interface Reference {
 interface Schema {
   properties: any;
   allOf: any;
+  oneOf: any;
   items: any;
   additionalProperties: any;
 }
@@ -35,6 +36,9 @@ export class SchemaNormalizer {
         resolved._pointer = resolved._pointer || ptr;
         resolved = Object.assign({}, resolved);
         AllOfMerger.merge(resolved, resolved.allOf);
+      }
+      if (resolved.oneOf) {
+          resolved.type = 'oneOf';
       }
       return resolved;
     });
@@ -72,6 +76,11 @@ class SchemaWalker {
     if (obj.allOf) {
       let ptr = JsonPointer.join(pointer, ['allOf']);
       SchemaWalker.walkEach(obj.allOf, ptr, visitor);
+    }
+
+    if (obj.oneOf) {
+      let ptr = JsonPointer.join(pointer, ['oneOf']);
+      SchemaWalker.walkEach(obj.oneOf, ptr, visitor);
     }
 
     if (obj.items) {

--- a/lib/services/schema-normalizer.service.ts
+++ b/lib/services/schema-normalizer.service.ts
@@ -224,9 +224,13 @@ class SchemaDereferencer {
     // if resolved schema doesn't have title use name from ref
     resolved.title = resolved.title || JsonPointer.baseName($ref);
 
-    let keysCount = Object.keys(schema).filter(key => !key.startsWith('x-redoc')).length;
+    let keysCount = Object.keys(schema)
+        .filter(key => !key.startsWith('x-redoc'))
+        .filter(key => key !== 'description')
+        .filter(key => key !== 'title')
+        .length;
 
-    if ( keysCount > 2 || (keysCount === 2 && !schema.description) ) {
+            if ( keysCount > 1 ) {
       WarningsService.warn(`Other properties are defined at the same level as $ref at "#${pointer}". ` +
         'They are IGNORED according to the JsonSchema spec');
       resolved.description = resolved.description || schema.description;

--- a/lib/utils/swagger-defs.ts
+++ b/lib/utils/swagger-defs.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-export const methods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch']);
+export const methods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch','js']);
 
 export const keywordTypes = {
   multipleOf: 'number',

--- a/lib/utils/swagger-defs.ts
+++ b/lib/utils/swagger-defs.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-export const methods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch','js']);
+export const methods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch']);
 
 export const keywordTypes = {
   multipleOf: 'number',


### PR DESCRIPTION
Clone some of the behaviour of tuple
Auto Sample for the first object.

Tested with sample spec like this:

```yml
      responses:
        '200':
          description: oneof
          schema:
            oneOf:
              - type: object
                title: myobject
                description: mydesc
                properties:
                    name:
                        type: string
                    age:
                        type: string
              - type: boolean
```