### PR TITLE
Slugifying non-ascii headers make duplicate permalinks

### DIFF
--- a/lib/utils/md-renderer.ts
+++ b/lib/utils/md-renderer.ts
@@ -53,6 +53,7 @@ export class MdRenderer {
   }
 
   saveHeading(title: string, parent:MarkdownHeading = {id:null, children: this.headings}) :MarkdownHeading {
+    // if title contains some non-ASCII characters (e.g. chinese) slugify returns empty string
     let slug = slugify(title) || title;
     let id = slug;
     if (parent && parent.id) id = `${parent.id}/${id}`;

--- a/lib/utils/md-renderer.ts
+++ b/lib/utils/md-renderer.ts
@@ -53,7 +53,7 @@ export class MdRenderer {
   }
 
   saveHeading(title: string, parent:MarkdownHeading = {id:null, children: this.headings}) :MarkdownHeading {
-    let slug = slugify(title);
+    let slug = slugify(title) || title;
     let id = slug;
     if (parent && parent.id) id = `${parent.id}/${id}`;
     parent.children = parent.children || {};


### PR DESCRIPTION
## Problem

I have following OpenAPI yaml which markdown headers are composed of non-ascii characters.

```yaml
swagger: "2.0"
info:
  title: サンプルAPI
  description: |
    # サンプルAPI

    サンプルのAPIドキュメントです。

    ## 利用手順

    はじめにデベロッパー登録してください。

    ## エラー

    以下のような形式でエラーを返します。
```

ReDoc will slugify these headers to make permanent links. However non-ascii-only header will be converted into same section names like this. They don't work well as permanent links.

```markdown
# サンプルAPI -> slugify -> "API" ->"/#section/API"

## 利用手順 -> slugify -> "" -> "/#section/API/"

## エラー -> slugify -> "" -> "/#section/API/"
```

I committed https://github.com/Joe-noh/ReDoc/commit/32f2f7f744c4ec15fb7b8ba243bf76c8c9970b26. This uses original header title if slugified title is empty. I guess this is simplest solution for this problem. Please let me know if there are any other good options.

Thanks. Joe.