### PR TITLE
fix: (#276) Issue with stick sidebar when there is content above reDoc

### DIFF
--- a/lib/shared/components/StickySidebar/sticky-sidebar.ts
+++ b/lib/shared/components/StickySidebar/sticky-sidebar.ts
@@ -40,7 +40,7 @@ export class StickySidebar implements OnInit, OnDestroy {
       this.unstick();
     }
 
-    if ( this.scrollY + window.innerHeight -  this.scrollYOffset() >= this.$redocEl.scrollHeight) {
+    if ( this.scrollY + window.innerHeight -  this.scrollYOffset() >= this.$redocEl.scrollHeight && this.$element.parentElement.parentElement.className != 'loading') {
       this.stickBottom();
       stuck = true;
     } else {


### PR DESCRIPTION
Seems like heights are being incorrectly calculated when initialising page. I've prevented this behaviour by looking at loading class name of redoc-wrap element.