### PR TITLE
use node-sass ^4.5.3, which supports NodeJS 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
     "mark.js": "github:julmot/mark.js",
-    "node-sass": "^4.5.2",
+    "node-sass": "^4.5.3",
     "openapi-sampler": "^0.4.1",
     "phantomjs-prebuilt": "^2.1.14",
     "prismjs": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,9 +3304,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
With the current version, on macOS, trying to start the local server with NodeJS 8 results in
```
Module build failed: Error: Node Sass does not yet support your current environment: 
OS X 64-bit with Unsupported runtime (57)
```