### PR TITLE
Downgrade deps, breaking prod. Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 - Install dependencies
 `npm install`
 - _(optional)_ Replace `demo/swagger.yaml` with your own schema
+- Create the compiled javascript file
+`npm run build:prod`
 - Start the server
 `npm start`
 - Open `http://localhost:9000`

--- a/package.json
+++ b/package.json
@@ -116,11 +116,11 @@
     "swagger-schema-official": "^2.0.0-bab6bed",
     "ts-helpers": "^1.1.1",
     "tslint": "^5.2.0",
-    "typescript": "^2.3.2",
+    "typescript": "2.3.4",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.5.0",
     "webpack-merge": "^4.1.0",
-    "zone.js": "^0.8.10"
+    "zone.js": "0.8.12"
   },
   "dependencies": {
     "lunr": "1.0.0",


### PR DESCRIPTION
Also fixes https://github.com/Rebilly/ReDoc/issues/293

Since typescript 2.4 the following errors occur:

```
[at-loader] ./lib/services/search.service.ts:195:24 
    TS2345: Argument of type 'Schema | Schema[]' is not assignable to parameter of type 'SwaggerSchema'.
  Type 'Schema[]' has no properties in common with type 'SwaggerSchema'. 
```

Downgrading to typescript 2.3.4 (the latest typescript 2.3.x series) fixes this.

On accessing the public page there were a variety of console errors that stemmed from zone 0.8.13 (https://github.com/angular/zone.js/issues/832). Downgrading to 0.8.12 fixed this error (and seems to be recommended)

I've also updated the docs to suggest running the prod build before npm start as otherwise you got the error:

```
[at-loader] Checking finished with 3 errors
[at-loader] ./lib/bootstrap.ts:2:36 
    TS2307: Cannot find module '../compiled/lib/app.module.ngfactory'. 
```

Because the compiled directory hadn't been created yet.