### PR TITLE
Fix event creation

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -21,7 +21,10 @@ export function mouseclick( element ) {
     // create a mouse click event
     var dispatchedEvent
     try {
-      dispatchedEvent = new MouseEvent('click', true);
+      dispatchedEvent = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: false
+      });
     } catch (e) {
       dispatchedEvent = document.createEvent('MouseEvent');
       dispatchedEvent.initEvent('click', true, false);


### PR DESCRIPTION
As per https://developer.mozilla.org/en/docs/Web/API/MouseEvent `true` isn't a valid parameter and causes an error to be thrown in typescript 2.4 (correctly). This set of parameters matches that in the catch below using `document.createEvent`