### PR TITLE
In JsonFormatter, output dates as ISO 8601 strings, per OpenAPI spec.

### DIFF
--- a/lib/utils/JsonFormatterPipe.ts
+++ b/lib/utils/JsonFormatterPipe.ts
@@ -35,6 +35,8 @@ function valueToHTML(value) {
     level++;
     output += arrayToHTML(value);
     level--;
+  } else if (value && value.constructor === Date) {
+    output += decorateWithSpan('"' + value.toISOString() + '"', 'type-string');
   } else if (valueType === 'object') {
     level++;
     output += objectToHTML(value);


### PR DESCRIPTION
Without this fix, `date-time` fields in examples get output as empty objects.