### PR TITLE
Add `display: inline-block` for `.openapi-button`

### DIFF
--- a/lib/components/ApiInfo/api-info.scss
+++ b/lib/components/ApiInfo/api-info.scss
@@ -17,6 +17,7 @@
   font-weight: normal;
   margin-left: 0.5em;
   padding: 3px 8px 4px;
+  display: inline-block;
 }
 
 :host /deep/ [section] {


### PR DESCRIPTION
Closes #320 