### PR TITLE
Closes #322: Feature request: Clickable logo that points to specific url

### DIFF
--- a/lib/components/ApiInfo/api-info.scss
+++ b/lib/components/ApiInfo/api-info.scss
@@ -9,6 +9,10 @@
   @media (max-width: $right-panel-squash-breakpoint) {
     width: 100%;
   }
+
+  @media (max-width: $side-menu-mobile-breakpoint) {
+    padding-top: $section-spacing + 20px;
+  }
 }
 
 .openapi-button {

--- a/lib/components/ApiLogo/api-logo.html
+++ b/lib/components/ApiLogo/api-logo.html
@@ -1,1 +1,4 @@
-<img *ngIf="logo.imgUrl" [attr.src]="logo.imgUrl" [ngStyle]="{'background-color': logo.bgColor}">
+<a *ngIf="logo.url" href="{{logo.url}}">
+    <img *ngIf="logo.imgUrl" [attr.src]="logo.imgUrl" [ngStyle]="{'background-color': logo.bgColor}">
+</a>
+<img *ngIf="logo.imgUrl && !logo.url" [attr.src]="logo.imgUrl" [ngStyle]="{'background-color': logo.bgColor}">

--- a/lib/components/ApiLogo/api-logo.ts
+++ b/lib/components/ApiLogo/api-logo.ts
@@ -17,6 +17,9 @@ export class ApiLogo extends BaseComponent implements OnInit {
 
   init() {
     let logoInfo = this.componentSchema.info['x-logo'];
+    if ('url' in this.componentSchema.info['contact']) {
+      this.logo.url = this.componentSchema.info['contact']['url'];
+    }
     if (!logoInfo) return;
     this.logo.imgUrl = logoInfo.url;
     this.logo.bgColor = logoInfo.backgroundColor || 'transparent';


### PR DESCRIPTION
Summary:

* #322: Feature request: Clickable logo that points to specific url
* Add "Return to website" link to the top right that leads to `info.contacts.url` if any.
* Increase padding top for `.api-info-wrapper` when left sidebar is hiding to avoid header overlaying by top menu.

@RomanGotsiy Unfortunately I don't do Angular, so I'm not sure if `lib/components/ApiInfo/api-info.html` is correct.

I, also, added a "Return to website" button, I need it, maybe someone need it, too. (It won't show up if no `url` in `contact` section of spec is present. Also, we can hide it with css `.go-back-link { display: none }`)

And I've noticed that  `.api-info-wrapper h1` becomes overlaid by top menu on small devices (once left sidebar is hiding), so I've increased the top padding for that.

I haven't found contributors rules in the repo, so I'm not sure if it is OK to do so. So let me know if anything is wrong and needs to be edited.

Thanks. 

UPDATE

Forgot to attach screenshot of the results: 
<img width="776" alt="redoc_return_link" src="https://user-images.githubusercontent.com/3235740/29375135-9f6b5e3c-82bc-11e7-97fa-b7ebbdfeb8ba.png">
