### PR TITLE
Add margins around list-items in markdown

### DIFF
--- a/lib/components/Redoc/redoc.scss
+++ b/lib/components/Redoc/redoc.scss
@@ -311,6 +311,9 @@ footer {
     font-family: $base-font, $base-font-family;
     font-weight: $base-font-weight;
     line-height: $base-line-height;
+    > li {
+      margin: 1em 0;
+    }
   }
 
   table {


### PR DESCRIPTION
They're pretty tightly squeezed in there right now.