### PR TITLE
add example to property infos

### DIFF
--- a/lib/components/JsonSchema/json-schema.html
+++ b/lib/components/JsonSchema/json-schema.html
@@ -77,6 +77,9 @@
               <div class="param-default" *ngIf="prop.default != null">
                 <span class="param-default-value">{{prop.default | json}}</span>
               </div>
+              <div class="param-example" *ngIf="prop.example != null">
+                <span class="param-example-value">{{prop.example | json}}</span>
+              </div>
               <div *ngIf="prop.enum && !prop.isDiscriminator" class="param-enum">
                 <span *ngFor="let enumItem of prop.enum" class="param-enum-value {{enumItem.type}}"> {{enumItem.val | json}} </span>
               </div>


### PR DESCRIPTION
As well as the _Default:_ being shown for each property. also allow the _Example:_ to be shown. Much like they are for parameters.