### PR TITLE
Make HTML5 attr `download` to work on "Download" button

### DIFF
--- a/lib/components/ApiInfo/api-info.html
+++ b/lib/components/ApiInfo/api-info.html
@@ -2,7 +2,7 @@
   <h1>{{info.title}} <span class="api-info-version">({{info.version}})</span></h1>
   <p class="download-openapi" *ngIf="specUrl">
     Download OpenAPI specification:
-    <a class="openapi-button" [attr.download]="downloadFilename" target="_blank" [attr.href]="specUrl"> Download </a>
+    <a class="openapi-button" [attr.download]="downloadFilename" [attr.href]="specUrl"> Download </a>
   </p>
   <p>
     <!-- TODO: create separate components for contact and license ? -->


### PR DESCRIPTION
Hi!

I'm not sure if you want such PR, but I've noticed that "Download" button on Safari opens spec instead of downloading. There was `download` attr already, but it didn't work because of `target="_blank"`. With this PR it is working.

Thanks!