### PR TITLE
Add note that x-logo SHOULD use absolute URLs

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -93,7 +93,7 @@ The information about API logo
 ###### Fixed fields
 | Field Name      |	Type	   | Description |
 | :-------------- | :------: | :---------- |
-| url             | string   | The URL pointing to the spec logo. MUST be in the format of a URL
+| url             | string   | The URL pointing to the spec logo. MUST be in the format of a URL. It SHOULD be an absolute URL so your API definition is usable from any location
 | backgroundColor | string   | background color to be used. MUST be RGB color in [hexadecimal format] (https://en.wikipedia.org/wiki/Web_colors#Hex_triplet)
 
 


### PR DESCRIPTION
Have seen a number of definitions designed for use with ReDoc using a relative logo URL. This 'breaks' when someone else (e.g. APIs.guru) hosts the API definition.