### PR TITLE
React Rewrite: A couple minor bug fixes

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -24,7 +24,7 @@ const DEFAULT_SPEC = 'openapi.yaml';
 class DemoApp extends React.Component<
   {},
   { specUrl: string; dropdownOpen: boolean; cors: boolean }
-  > {
+> {
   constructor(props) {
     super(props);
 

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import styled from 'styled-components';
 import { resolve as urlResolve } from 'url';
-import { RedocStandalone } from '../';
+import { RedocStandalone } from '../src';
 import ComboBox from './ComboBox';
 
 const demos = [
@@ -24,7 +24,7 @@ const DEFAULT_SPEC = 'openapi.yaml';
 class DemoApp extends React.Component<
   {},
   { specUrl: string; dropdownOpen: boolean; cors: boolean }
-> {
+  > {
   constructor(props) {
     super(props);
 

--- a/demo/webpack.config.ts
+++ b/demo/webpack.config.ts
@@ -28,6 +28,10 @@ export default {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
   },
+  
+  node: {
+    fs: 'empty',
+  },
 
   module: {
     rules: [
@@ -53,6 +57,17 @@ export default {
           options: {
             sourceMap: true,
             minimize: true,
+          },
+        },
+      },
+      {
+        test: /node_modules\/(swagger2openapi|reftools)\/.*\.js$/,
+        use: {
+          loader: 'awesome-typescript-loader',
+          options: {
+            transpileOnly: true,
+            allowJs: true,
+            instance: 'ts2js-transpiler-only',
           },
         },
       },

--- a/src/components/SelectOnClick/SelectOnClick.tsx
+++ b/src/components/SelectOnClick/SelectOnClick.tsx
@@ -5,7 +5,7 @@ import { ClipboardService } from '../../services';
 export class SelectOnClick extends React.PureComponent {
   private child: HTMLDivElement | null;
   handleClick = () => {
-    ClipboardService.selectElement(this.refs.child);
+    ClipboardService.selectElement(this.child);
   };
 
   render() {

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -105,7 +105,7 @@ export class OpenAPIParser {
     } catch (e) {
       // do nothing
     }
-    return res;
+    return res || {};
   };
 
   /**


### PR DESCRIPTION
* SelectOnClick has been fixed. This was crashing.
* When OpenAPIParser was dereferencing a schema and the ref was not found, it would return undefined. This would crash other segments of the code such as `if (schema.allOf === undefined) {`