### PR TITLE
Modify the peerDependencies to reflect the need for react 16.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "yaml-js": "^0.2.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.3.0-alpha.2",
+    "react-dom": "^16.3.0-alpha.2"
   },
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.0.0-beta.42",


### PR DESCRIPTION
When using the alpha build of ReDoc, running in an environment with React 16.2.0 results in an error due to the missing `createContext` API. This PR updates the package.json `peerDependencies` to reflect the need for react >= 16.3