### PR TITLE
parse discriminator value from the referenced scheme

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -280,7 +280,7 @@ export class OpenAPIParser {
         def.allOf !== undefined &&
         def.allOf.find(obj => obj.$ref !== undefined && $refs.indexOf(obj.$ref) > -1)
       ) {
-        res['#/components/schemas/' + defName] = defName;
+        res['#/components/schemas/' + defName] = def['x-discriminator-value'] || defName;
       }
     }
     return res;


### PR DESCRIPTION
Add vendor extension used by swagger-codegen for Swagger 2.0 as an alternative to OpenAPI 3.0 mapping feature.
For example: https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/resources/python/model.mustache