### PR TITLE
Update swagger2openapi to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "slugify": "^1.2.1",
     "stickyfill": "^1.1.1",
     "styled-components": "^3.3.3",
-    "swagger2openapi": "^2.11.0",
+    "swagger2openapi": "^3.1.2",
     "tslib": "^1.9.3"
   },
   "resolutions": {


### PR DESCRIPTION
This includes the fix for x-discriminator. 

Fixes #496.