### PR TITLE
bugfix/2018.07.16_fix-closing-script-tag

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -236,7 +236,7 @@ async function getPageHTML(
     redocHTML: `
     <div id="redoc">${(ssr && html) || ''}</div>
     <script>
-    ${(ssr && `const __redoc_state = ${escapeUnicode(JSON.stringify(state))};`) || ''}
+    ${(ssr && `/*<!--*/const __redoc_state = ${escapeUnicode(JSON.stringify(state))};/*-->*/`) || ''}
 
     var container = document.getElementById('redoc');
     Redoc.${


### PR DESCRIPTION
### Changes
- fix index.ts __redoc_state rendering
    - add commented out HTML comments
    - should now handle `</script>` tags (see #563)
