### PR TITLE
Fix minor spelling errors in vendor extensions docs

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -202,7 +202,7 @@ Extends OpenAPI [Parameter Object](http://swagger.io/specification/#parameterObj
 `x-examples` are rendered in the JSON tab on the right panel of ReDoc.
 
 ### Response Object vendor extensions
-Extneds OpeanAPI [Response Object](https://swagger.io/specification/#responseObject)
+Extends OpenAPI [Response Object](https://swagger.io/specification/#responseObject)
 
 #### x-summary
 | Field Name     |	Type	  | Description |


### PR DESCRIPTION
Fixed some minor spelling errors in the Vendor Extensions document for the Response Object vendor extension.