### PR TITLE
Increase badge size slightly so that "PATCH" method fits inside better

### DIFF
--- a/src/components/SideMenu/MenuItem.tsx
+++ b/src/components/SideMenu/MenuItem.tsx
@@ -95,7 +95,7 @@ class OperationMenuItemContent extends React.Component<OperationMenuItemContentP
         deprecated={item.deprecated}
       >
         <OperationBadge type={item.httpVerb}>{shortenHTTPVerb(item.httpVerb)}</OperationBadge>
-        <MenuItemTitle width="calc(100% - 32px)">
+        <MenuItemTitle width="calc(100% - 38px)">
           {item.name}
           {this.props.children}
         </MenuItemTitle>

--- a/src/components/SideMenu/styled.elements.ts
+++ b/src/components/SideMenu/styled.elements.ts
@@ -6,7 +6,7 @@ import styled, { css, withProps } from '../../styled-components';
 export const OperationBadge = withProps<{ type: string }>(styled.span).attrs({
   className: props => `operation-type ${props.type}`,
 })`
-  width: 26px;
+  width: 32px;
   display: inline-block;
   height: ${props => props.theme.typography.code.fontSize};
   line-height: ${props => props.theme.typography.code.fontSize};


### PR DESCRIPTION
This pull request fixes an issue where the "PATCH" method does not fit inside the badge very nicely at the cost of some horizontal space for the summary.

**Before:**

<img width="270" alt="screen shot 2018-09-03 at 20 45 23" src="https://user-images.githubusercontent.com/10126466/44998989-4f0f9800-afba-11e8-8534-be3d87c0ac39.png">

**After:**

<img width="271" alt="screen shot 2018-09-03 at 20 40 03" src="https://user-images.githubusercontent.com/10126466/44998903-90ec0e80-afb9-11e8-80c9-f632a5b0bedf.png">
