### PR TITLE
Corrected Docker Port in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ You can also specify `onLoaded` callback which will be called each time Redoc ha
 ReDoc is available as pre-built Docker image in official [Docker Hub repository](https://hub.docker.com/r/redocly/redoc/). You may simply pull & run it:
 
     docker pull redocly/redoc
-    docker run -p 80:8080 redocly/redoc
+    docker run -p 8080:80 redocly/redoc
 
 Also you may rewrite some predefined environment variables defined in [Dockerfile](./Dockerfile). By default ReDoc starts with demo Petstore spec located at `http://petstore.swagger.io/v2/swagger.json`, but you may change this URL using environment variable `SPEC_URL`:
 
-    docker run -p 80:8080 -e SPEC_URL=https://api.example.com/openapi.json redocly/redoc
+    docker run -p 8080:80 -e SPEC_URL=https://api.example.com/openapi.json redocly/redoc
 
 ## ReDoc CLI
 


### PR DESCRIPTION
The command to launch ReDoc with Docker had the `-p` values reversed.
According to the Docker Docs, it should be `HOST_PORT:CLIENT_PORT`.
The Nginx service is running on port 80 inside the container, 8080 is the 
port exposed on the host.