### PR TITLE
Fix for property description with $ref

### DIFF
--- a/lib/services/schema-normalizer.service.ts
+++ b/lib/services/schema-normalizer.service.ts
@@ -229,11 +229,18 @@ export class SchemaDereferencer {
     if ( keysCount > 2 || (keysCount === 2 && !schema.description) ) {
       WarningsService.warn(`Other properties are defined at the same level as $ref at "#${pointer}". ` +
         'They are IGNORED according to the JsonSchema spec');
-      resolved.description = resolved.description || schema.description;
     }
 
     resolved = this.normalizator.normalize(resolved, $ref);
     this._refCouner.exit($ref);
+
+    // schema description should always override $ref description
+    if (schema.description) {
+      // make a copy of resolved object with updated description, do not globally override the description
+      resolved = Object.assign({}, resolved);
+      resolved.description = schema.description;
+    }
+
     return resolved;
   }
 }


### PR DESCRIPTION
Current versions of ReDoc applications (1.x and 2.x) have an issue to properly display property description if it contains `$ref` to the schema object. At best ReDoc displays the original `description` of the schema object.

For example, this YAML description of [Demo REST API](https://github.com/darklynx/swagger-api-collection/blob/master/api/yaml/prop-desc-demo.yaml):
```YAML
...
definitions:
  Company:
    type: object
    description: Company short description
    properties:
      name:
        type: string
        description: Company name
        example: Secret agency
      ceo:
        $ref: '#/definitions/Person'
        description: CEO of the company
      cto:
        $ref: '#/definitions/Person'
        description: CTO of the company
      employees:
        type: array
        description: Company employees
        items:
          $ref: '#/definitions/Person'
      visitor:
        $ref: '#/definitions/Person'
  Person:
    type: object
    description: Brief information about a person
...
```

will be displayed in **ReDoc v.1.22.2** as following:
![ReDoc v.1.22.2](https://i.imgur.com/YazlEYD.png)

**ReDoc v2.0.0-alpha.41** has similar issue:
![ReDoc v2.0.0-alpha.41](https://i.imgur.com/VGu6Jji.png)

**Expected behavior**
This PR changes the logic of rendering in a way that description next to the property, if present, overrides the original description from referred schema object:
![ReDoc v1.22.2 (fixed)](https://i.imgur.com/llsWJMw.png)

Note: I did not have a chance to look into the ReDoc version 2, but I saw that the structure of the project has changed and the logic from `schema-normalizer.service.ts` was moved somewhere else.