### PR TITLE
chore: use tarball url for marked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "json-schema-ref-parser": "^6.0.1",
     "lunr": "^2.3.2",
     "mark.js": "^8.11.1",
-    "marked": "https://github.com/markedjs/marked#fb48827",
+    "marked": "https://github.com/markedjs/marked/archive/fb48827.tar.gz",
     "memoize-one": "^4.0.0",
     "mobx-react": "^5.2.5",
     "openapi-sampler": "1.0.0-beta.14",


### PR DESCRIPTION
Allow the dependency to be installed without git.