### PR TITLE
Updated marked to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "json-schema-ref-parser": "^6.0.1",
     "lunr": "^2.3.2",
     "mark.js": "^8.11.1",
-    "marked": "https://github.com/markedjs/marked#fb48827",
+    "marked": "^0.5.2",
     "memoize-one": "^4.0.0",
     "mobx-react": "^5.2.5",
     "openapi-sampler": "1.0.0-beta.14",


### PR DESCRIPTION
Now that marked.js has published a new version you can remove the dependency to specific git commit so we can fetch all dependencies from official releases to npmjs.