### PR TITLE
docs: fix link to OpenAPI specification in vendor extensions doc

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -206,7 +206,7 @@ Extends OpenAPI [Parameter Object](http://swagger.io/specification/#parameterObj
 `x-examples` are rendered in the JSON tab on the right panel of ReDoc.
 
 ### Response Object vendor extensions
-Extends OpenAPI [Response Object](https://swagger.io/specification/#requestBodyObject)
+Extends OpenAPI [Response Object](https://swagger.io/specification/#responseObject)
 
 #### x-summary
 | Field Name     |	Type	  | Description |


### PR DESCRIPTION
Goofed one of the links in my last [PR](https://github.com/Rebilly/ReDoc/pull/728), the site handles anchor tags weirdly. I think everything else is correct now :) 