### PR TITLE
Add FastAPI to real-life usages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additionally, all the 1.x releases are hosted on our GitHub Pages-based **CDN**:
 - [Shopify Draft Orders](https://help.shopify.com/api/draft-orders)
 - [Discourse](http://docs.discourse.org)
 - [APIs.guru](https://apis.guru/api-doc/)
+- [FastAPI](https://github.com/tiangolo/fastapi)
 
 ## Deployment
 


### PR DESCRIPTION
This PR adds [FastAPI](https://github.com/tiangolo/fastapi) to the section about real-life usages in the `README.md`.

The link is pointing to the GitHub repo: https://github.com/tiangolo/fastapi

But let me know if it would be better to point to the website / docs: https://fastapi.tiangolo.com/