### PR TITLE
Only display API version if present

### DIFF
--- a/src/components/ApiInfo/ApiInfo.tsx
+++ b/src/components/ApiInfo/ApiInfo.tsx
@@ -70,12 +70,18 @@ export class ApiInfo extends React.Component<ApiInfoProps> {
       )) ||
       null;
 
+    const version =
+      (info.version && (
+        <span>({info.version})</span>
+      )) ||
+      null;
+
     return (
       <Section>
         <Row>
           <MiddlePanel className="api-info">
             <ApiHeader>
-              {info.title} <span>({info.version})</span>
+              {info.title} {version}
             </ApiHeader>
             {!hideDownloadButton && (
               <p>

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -63,6 +63,12 @@ export class OpenAPIParser {
     if (spec.openapi === undefined) {
       throw new Error('Document must be valid OpenAPI 3.0.0 definition');
     }
+    if (spec.info === undefined) {
+      throw new Error('OpenAPI 3.0.0 requires an `info` section');
+    }
+    if (spec.info.version === undefined) {
+      console.warn('OpenAPI 3.0.0 requires setting a `info.version` field, ignoring.')
+    }
   }
 
   preprocess(spec: OpenAPISpec) {


### PR DESCRIPTION
This only displays the version if it is specified in the info section:

## Before 

![image](https://user-images.githubusercontent.com/606968/50829135-c461ef80-1343-11e9-8c16-d4c3d85a94ff.png)

## After 

![image](https://user-images.githubusercontent.com/606968/50829060-8a90e900-1343-11e9-863f-65e794b1a900.png)

This is useful for OpenAPI specifications that bundle several APIs that are versioned independently, hence the global version string makes little sense.