### PR TITLE
Incorrect port after restart when PORT is 8080

### DIFF
--- a/config/docker/docker-run.sh
+++ b/config/docker/docker-run.sh
@@ -6,6 +6,6 @@ sed -i -e "s|%PAGE_TITLE%|$PAGE_TITLE|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%PAGE_FAVICON%|$PAGE_FAVICON|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%SPEC_URL%|$SPEC_URL|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%REDOC_OPTIONS%|${REDOC_OPTIONS}|g" /usr/share/nginx/html/index.html
-sed -i -e "s|80|${PORT}|g" /etc/nginx/nginx.conf
+sed -i -e "s|\(listen\s*\) [0-9]*|\1 ${PORT}|g" /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
When PORT is 8080 and dokcer restart, nginx will listen 80808080