### PR TITLE
Fix documentation of x-traitTag extension

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -134,13 +134,6 @@ Extends OpenAPI [Tag Object](http://swagger.io/specification/#tagObject)
 | :------------- | :------: | :---------- |
 | x-traitTag     | boolean  | In Swagger two operations can have multiple tags. This property distinguishes between tags that are used to group operations (default) from tags that are used to mark operation with certain trait (`true` value) |
 
-#### x-displayName
-
-| Field Name     |	Type	  | Description |
-| :------------- | :------: | :---------- |
-| x-displayName  | string   | Defines the text that is used for this tag in the menu and in section headings |
-
-
 ###### Usage in Redoc
 Tags that have `x-traitTag` set to `true` are listed in side-menu but don't have any subitems (operations). Tag `description` is rendered as well.
 This is useful for handling out common things like Pagination, Rate-Limits, etc.
@@ -160,6 +153,12 @@ name: Pagination
 description: Pagination description (can use markdown syntax)
 x-traitTag: true
 ```
+
+#### x-displayName
+
+| Field Name     |	Type	  | Description |
+| :------------- | :------: | :---------- |
+| x-displayName  | string   | Defines the text that is used for this tag in the menu and in section headings |
 
 ### Operation Object vendor extensions
 Extends OpenAPI [Operation Object](http://swagger.io/specification/#operationObject)


### PR DESCRIPTION
**Affected version:**
v2.0.0-rc.2

**Problem:**
The documentation for `x-displayName` ([link](https://github.com/Rebilly/ReDoc/blob/v2.0.0-rc.2/docs/redoc-vendor-extensions.md#x-displayname)) had been added into the middle of the `x-traitTag` section ([link](https://github.com/Rebilly/ReDoc/blob/v2.0.0-rc.2/docs/redoc-vendor-extensions.md#x-traittag)), splitting the original section and moving its example ([link](https://github.com/Rebilly/ReDoc/blob/v2.0.0-rc.2/docs/redoc-vendor-extensions.md#usage-in-redoc-3)) to the wrong extension.

**Solution:**
Just move a couple of lines.