### PR TITLE
fix: escape backslashes in string literals

### DIFF
--- a/src/utils/jsonToHtml.ts
+++ b/src/utils/jsonToHtml.ts
@@ -21,8 +21,8 @@ function htmlEncode(t) {
     : '';
 }
 
-function escapeStringQuotes(str: string) {
-  return str.replace(/"/g, '\\"');
+function escapeForStringLiteral(str: string) {
+  return str.replace(/([\\"])/g, '\\$1');
 }
 
 function decorateWithSpan(value, className) {
@@ -57,11 +57,11 @@ function valueToHTML(value) {
         '<a href="' +
         value +
         '">' +
-        htmlEncode(escapeStringQuotes(value)) +
+        htmlEncode(escapeForStringLiteral(value)) +
         '</a>' +
         decorateWithSpan('"', 'token string');
     } else {
-      output += decorateWithSpan('"' + escapeStringQuotes(value) + '"', 'token string');
+      output += decorateWithSpan('"' + escapeForStringLiteral(value) + '"', 'token string');
     }
   } else if (valueType === 'boolean') {
     output += decorateWithSpan(value, 'token boolean');


### PR DESCRIPTION
Follow up for #822 and 04731656 (only escape quotes).

When `example: '{"name":"Guru \ bs"}'` is given...

before:
![image](https://user-images.githubusercontent.com/705555/53401717-b2233a00-39f3-11e9-9448-800d9d72c6fc.png)

after:
![image](https://user-images.githubusercontent.com/705555/53401640-8d2ec700-39f3-11e9-8f2d-ceae8065237b.png)
