### PR TITLE
Display requestBody description #833

### DIFF
--- a/src/components/Parameters/Parameters.tsx
+++ b/src/components/Parameters/Parameters.tsx
@@ -4,11 +4,12 @@ import { ParametersGroup } from './ParametersGroup';
 
 import { UnderlinedHeader } from '../../common-elements';
 
+import { MediaContentModel } from '../../services';
 import { FieldModel, RequestBodyModel } from '../../services/models';
 import { MediaTypesSwitch } from '../MediaTypeSwitch/MediaTypesSwitch';
 import { Schema } from '../Schema';
 
-import { MediaContentModel } from '../../services';
+import { Markdown } from '../Markdown/Markdown';
 
 function safePush(obj, prop, item) {
   if (!obj[prop]) {
@@ -45,13 +46,15 @@ export class Parameters extends React.PureComponent<ParametersProps> {
 
     const bodyContent = body && body.content;
 
+    const bodyDescription = body && body.description;
+
     return (
-      <div>
+      <>
         {paramsPlaces.map(place => (
           <ParametersGroup key={place} place={place} parameters={paramsMap[place]} />
         ))}
-        {bodyContent && <BodyContent content={bodyContent} />}
-      </div>
+        {bodyContent && <BodyContent content={bodyContent} description={bodyDescription} />}
+      </>
     );
   }
 }
@@ -64,12 +67,17 @@ function DropdownWithinHeader(props) {
   );
 }
 
-function BodyContent(props: { content: MediaContentModel }): JSX.Element {
-  const { content } = props;
+function BodyContent(props: { content: MediaContentModel; description?: string }): JSX.Element {
+  const { content, description } = props;
   return (
     <MediaTypesSwitch content={content} renderDropdown={DropdownWithinHeader}>
       {({ schema }) => {
-        return <Schema skipReadOnly={true} key="schema" schema={schema} />;
+        return (
+          <>
+            {description !== undefined && <Markdown source={description} />}
+            <Schema skipReadOnly={true} key="schema" schema={schema} />
+          </>
+        );
       }}
     </MediaTypesSwitch>
   );


### PR DESCRIPTION
After migrating to ReDoc we noticed that some of descriptions from our OpenAPI 3.0 spec that were previously visible in swagger-ui has disappeared. 

One of the examples is description in requestBody (this missing feature was already referenced in comment to issue https://github.com/Rebilly/ReDoc/issues/598#issuecomment-437287835 and in this issue).

We were able to mitigate this problem by moving relevant descriptions from requestBodies up to request method level, but for the sake of completeness i decided to propose this PR.

Please comment if you are interested in incorporating this feature and if you are ok with this particular implementation.

![screenshot 2019-03-08 at 11 04 11](https://user-images.githubusercontent.com/4971260/54023390-1fbe2b80-4195-11e9-8d8d-1fd39a0a9ecc.png)
