### PR TITLE
Tidy up non-redoc extension presentation

### DIFF
--- a/src/common-elements/fields.ts
+++ b/src/common-elements/fields.ts
@@ -88,6 +88,8 @@ export const ExampleValue = styled(FieldLabel)`
   ${extensionsHook('ExampleValue')};
 `;
 
+export const ExtensionValue = styled(ExampleValue)``;
+
 export const ConstraintItem = styled(FieldLabel)`
   border-radius: 2px;
   ${({ theme }) => `

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -1,4 +1,9 @@
 import * as React from 'react';
+
+import { startCase } from 'lodash';
+
+import { FieldLabel } from '../../common-elements/fields';
+
 import styled from '../../styled-components';
 
 import { OptionsContext } from '../OptionsProvider';
@@ -8,10 +13,6 @@ import { StyledMarkdownBlock } from '../Markdown/styled.elements';
 const Extension = styled(StyledMarkdownBlock)`
   opacity: 0.9;
   margin: 2px 0;
-`;
-
-const ExtensionLable = styled.span`
-  font-style: italic;
 `;
 
 export interface ExtensionsProps {
@@ -29,8 +30,10 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
-                  <ExtensionLable>{key}</ExtensionLable>:{' '}
-                  <code>{JSON.stringify(this.props.extensions[key])}</code>
+                  <FieldLabel>{startCase(key.substring(2))}</FieldLabel>:{' '}
+                  <code>
+                    {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
+                  </code>
                 </Extension>
               ))}
           </>

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FieldLabel } from '../../common-elements/fields';
+import { FieldLabel, ExtensionValue } from '../../common-elements/fields';
 
 import styled from '../../styled-components';
 
@@ -9,7 +9,6 @@ import { OptionsContext } from '../OptionsProvider';
 import { StyledMarkdownBlock } from '../Markdown/styled.elements';
 
 const Extension = styled(StyledMarkdownBlock)`
-  opacity: 0.9;
   margin: 2px 0;
 `;
 
@@ -28,10 +27,8 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
-                  <FieldLabel>{key.substring(2)}:</FieldLabel>{' '}
-                  <code>
-                    {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
-                  </code>
+                  <FieldLabel>{key.substring(2)}:</FieldLabel>
+                  <ExtensionValue>{JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}</ExtensionValue>
                 </Extension>
               ))}
           </>

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -27,7 +27,7 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
-                  <FieldLabel>{key.substring(2)}:</FieldLabel>
+                  <FieldLabel> {key.substring(2)}: </FieldLabel>{' '}
                   <ExtensionValue>
                     {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
                   </ExtensionValue>

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -28,7 +28,7 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
-                  <FieldLabel>{key.substring(2)}</FieldLabel>:{' '}
+                  <FieldLabel>{key.substring(2)}:</FieldLabel>{' '}
                   <code>
                     {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
                   </code>

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -28,7 +28,9 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
                   <FieldLabel>{key.substring(2)}:</FieldLabel>
-                  <ExtensionValue>{JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}</ExtensionValue>
+                  <ExtensionValue>
+                    {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
+                  </ExtensionValue>
                 </Extension>
               ))}
           </>

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FieldLabel, ExtensionValue } from '../../common-elements/fields';
+import { ExtensionValue, FieldLabel } from '../../common-elements/fields';
 
 import styled from '../../styled-components';
 

--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { startCase } from 'lodash';
-
 import { FieldLabel } from '../../common-elements/fields';
 
 import styled from '../../styled-components';
@@ -30,7 +28,7 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(this.props.extensions).map(key => (
                 <Extension key={key}>
-                  <FieldLabel>{startCase(key.substring(2))}</FieldLabel>:{' '}
+                  <FieldLabel>{key.substring(2)}</FieldLabel>:{' '}
                   <code>
                     {JSON.stringify(this.props.extensions[key]).replace(/(^")|("$)/g, '')}
                   </code>


### PR DESCRIPTION
This PR:

- Standardises an extension to use the `FieldLabel` component rather than a bespoke one so the style matches
- Removes the `x-` prefix from the extension when presenting the name on the page
- Title cases the unprefixed extension name
- Removes the extraneous `"` quotes from either side of the extension value, so strings like `test` are displayed as `test` and not `"test"`


Before:
![image](https://user-images.githubusercontent.com/7688837/54425930-79cb6d80-470e-11e9-8c05-5eeb3a790823.png)
(where we're using `x-scope` to annotate the scope required for a particular field to be populated from our API above and beyond the scope needed to access the endpoint itself, which is defined in security objects etc)

After:
![image](https://user-images.githubusercontent.com/7688837/54425127-759e5080-470c-11e9-873e-69b5c716f0bc.png)