### PR TITLE
Revert styled-components to 4.1.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "redoc": "^2.0.0-rc.4",
-    "styled-components": "^4.1.12",
+    "styled-components": "^4.1.1",
     "tslib": "^1.9.3",
     "yargs": "^12.0.5"
   },


### PR DESCRIPTION
Reverts change in 6b152c67ef8d20f5998e9e45c8426d2bd0dc7f3e that made the ReDoc uninstallable.

Fixes #848 