### PR TITLE
fixes typo in error message for detecting a circular dependency in theme.ts

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -166,7 +166,7 @@ export function resolveTheme(theme: ThemeInterface): ResolvedThemeInterface {
               counter++;
               if (counter > 1000) {
                 throw new Error(
-                  `Theme probably contains cirucal dependency at ${currentPath}: ${val.toString()}`,
+                  `Theme probably contains circular dependency at ${currentPath}: ${val.toString()}`,
                 );
               }
 


### PR DESCRIPTION
This PR fixes the typo here:

https://github.com/Rebilly/ReDoc/blob/dc77d8f25e8d9f198eb1135b01eb5b04dc9555ec/src/theme.ts#L169