### PR TITLE
fix #860 change fontFamily for EndpointInfo

### DIFF
--- a/src/components/Endpoint/styled.elements.ts
+++ b/src/components/Endpoint/styled.elements.ts
@@ -7,7 +7,7 @@ export const OperationEndpointWrap = styled.div`
 `;
 
 export const ServerRelativeURL = styled.span`
-  font-family: ${props => props.theme.typography.headings.fontFamily};
+  font-family: ${props => props.theme.typography.code.fontFamily};
   margin-left: 10px;
   flex: 1;
   overflow-x: hidden;


### PR DESCRIPTION
As seen in #860 , this PR aims to change the font used in the "path" section of the generated doc, from the "headings" to the "code" font-family.