### PR TITLE
add additional property to theme usage doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Also you can pass options:
   specUrl="http://rebilly.github.io/RebillyAPI/openapi.json"
   options={{
     nativeScrollbars: true,
-    theme: { colors: { main: '#dd5522' } },
+    theme: { colors: { primary { main: '#dd5522' } } },
   }}
 />
 ```


### PR DESCRIPTION
"theme: { colors: { main: '#dd5522' } }" didn't work for me.