### PR TITLE
Remove querystring from exposed URL

### DIFF
--- a/src/components/Endpoint/Endpoint.tsx
+++ b/src/components/Endpoint/Endpoint.tsx
@@ -5,7 +5,7 @@ import { Markdown } from '../Markdown/Markdown';
 import { OptionsContext } from '../OptionsProvider';
 import { SelectOnClick } from '../SelectOnClick/SelectOnClick';
 
-import { getBasePath } from '../../utils';
+import {getBasePath, removeQueryString} from '../../utils';
 import {
   EndpointInfo,
   HttpVerb,
@@ -68,7 +68,7 @@ export class Endpoint extends React.Component<EndpointProps, EndpointState> {
                       <span>
                         {hideHostname || options.hideHostname
                           ? getBasePath(server.url)
-                          : server.url}
+                          : removeQueryString(server.url)}
                       </span>
                       {operation.path}
                     </ServerUrl>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -165,3 +165,9 @@ export function resolveUrl(url: string, to: string) {
 export function getBasePath(serverUrl: string): string {
   return new URL(serverUrl).pathname;
 }
+
+export function removeQueryString(serverUrl: string): string {
+  const url = new URL(serverUrl);
+  url.search = '';
+  return url.toString();
+}


### PR DESCRIPTION
If ReDoc is initiated on a page containing query strings in the URL, the generated URL is misbehaving as shown on the following image

<img width="1238" alt="Capture d’écran 2019-04-19 à 15 32 02" src="https://user-images.githubusercontent.com/4977112/56426350-53be5d80-62b8-11e9-89e7-510fbdad8f82.png">

Live example at https://demo.api-platform.com/?ui=re_doc&spec_version=3

After this change the exposed URL would be `https://demo.api-platform.com/books` as expected